### PR TITLE
Fix typo in login and register

### DIFF
--- a/cypress/e2e/login.cy.js
+++ b/cypress/e2e/login.cy.js
@@ -1,5 +1,5 @@
 let movies;
-describe("User funcitonality", () => {
+describe("User functionality", () => {
     
     describe("Login Page", () => {
         it("Should log in and display the home page", () => {

--- a/cypress/e2e/register.cy.js
+++ b/cypress/e2e/register.cy.js
@@ -1,5 +1,5 @@
 import {randomEmail} from '../support/e2e'
-describe("User funcitonality", () => {
+describe("User functionality", () => {
     
     describe("Login Page", () => {
         it("should register a new user and display the home page", () => {


### PR DESCRIPTION
This PR fixes a typo spotted in the login and register test files, where functionality was spelled as 'funcitonality'.